### PR TITLE
Fix git repository name in build_devcontainer.yml CI workflow

### DIFF
--- a/.github/workflows/build_devcontainer.yml
+++ b/.github/workflows/build_devcontainer.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Compute Image Name
         id: image_name
         run: |
-          if [ "${{ github.repository }}/${{ github.ref }}" != "bemanproject/infra/refs/heads/main" ]; then
+          if [ "${{ github.repository }}/${{ github.ref }}" != "bemanproject/containers/refs/heads/main" ]; then
             image_name="${{ env.DEBUG_NAME }}"
             tag="${{ matrix.usage }}-${{ matrix.compilers.kind }}-${{ matrix.compilers.version }}"
           else


### PR DESCRIPTION
Previously, this check hardcoded the canonical repository name as "infra"; it's now "containers," so this commit updates the name to reflect that.