### PR TITLE
Bump Clang trunk major version to 22

### DIFF
--- a/.github/workflows/fromsource_ci.yml
+++ b/.github/workflows/fromsource_ci.yml
@@ -36,7 +36,7 @@ jobs:
             compiler-version: 21.0.0.9999
             tags: [latest, trunk]
           - kind: clang
-            compiler-version: 21.0.0.9999
+            compiler-version: 22.0.0.9999
             tags: [trunk]
           - kind: gcc
             compiler-version: 16.0.9999


### PR DESCRIPTION
Reflecting this change made by llvm upstream:

https://github.com/llvm/llvm-project/commit/01f36b39bd2475a271bbeb95fb9db8ed65e2d065