### PR TITLE
Clang 21 and various compiler version bumps

### DIFF
--- a/.github/workflows/fromsource_ci.yml
+++ b/.github/workflows/fromsource_ci.yml
@@ -36,8 +36,11 @@ jobs:
             compiler-version: 21.0.0.9999
             tags: [latest, trunk]
           - kind: clang
-            compiler-version: 21.0.0.9999
+            compiler-version: 22.0.0_pre20250910
             tags: [trunk]
+          - kind: clang
+            compiler-version: 21.1.1
+            tags: [21.1.1, 21, latest]
           - kind: gcc
             compiler-version: 16.0.9999
             tags: [trunk]

--- a/.github/workflows/testing_ci.yml
+++ b/.github/workflows/testing_ci.yml
@@ -31,29 +31,29 @@ jobs:
       matrix:
         compilers:
           - kind: gcc
-            compiler-version: 15.1.0
-            tags: [15.1.0, 15, latest]
+            compiler-version: 15.2.0
+            tags: [15.2.0, 15, latest]
           - kind: gcc
             compiler-version: 14.3.0
             tags: [14.3.0, 14]
           - kind: gcc
-            compiler-version: 13.4.0
-            tags: [13.4.0, 13]
+            compiler-version: 13.4.1_p20250807
+            tags: [13.4.1, 13]
           - kind: gcc
-            compiler-version: 12.4.1_p20250704
-            tags: [12.4.1, 12]
+            compiler-version: 12.5.0
+            tags: [12.5.0, 12]
           - kind: gcc
             compiler-version: 11.5.0
             tags: [11.5.0, 11]
           - kind: clang
-            compiler-version: 20.1.7
-            tags: [20.1.7, 20, latest]
+            compiler-version: 20.1.8
+            tags: [20.1.8, 20]
           - kind: clang
             compiler-version: 19.1.7
             tags: [19.1.7, 19]
           - kind: clang
             compiler-version: 18.1.8-r6
-            tags: [18.1.6, 18]
+            tags: [18.1.8, 18]
           - kind: clang
             compiler-version: 17.0.6
             tags: [17.0.6, 17]

--- a/Dockerfile.fromsource
+++ b/Dockerfile.fromsource
@@ -25,8 +25,13 @@ EOF2
       emerge --sync
     fi
     echo 'ACCEPT_KEYWORDS="~amd64"' >> /etc/portage/make.conf
-    echo "=dev-build/cmake-4.0.3" >> /etc/portage/package.unmask
-    emerge =dev-build/cmake-4.0.3
+    if [[ ${compiler_kind} == clang-p2996 ]] ; then
+      echo "=dev-build/cmake-4.0.3" >> /etc/portage/package.unmask
+      emerge =dev-build/cmake-4.0.3
+    else
+      echo "=dev-build/cmake-4.1.1" >> /etc/portage/package.unmask
+      emerge =dev-build/cmake-4.1.1
+    fi
     emerge dev-build/ninja
     emerge dev-util/gcovr
     if [[ ${compiler_kind} == clang* ]] ; then

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -10,8 +10,8 @@ RUN /bin/bash <<"EOF"
     emerge-webrsync
     getuto
     echo 'ACCEPT_KEYWORDS="~amd64"' >> /etc/portage/make.conf
-    echo "=dev-build/cmake-4.0.3" >> /etc/portage/package.unmask
-    emerge =dev-build/cmake-4.0.3
+    echo "=dev-build/cmake-4.1.1" >> /etc/portage/package.unmask
+    emerge =dev-build/cmake-4.1.1
     emerge dev-build/ninja
     emerge dev-vcs/git
     emerge dev-util/gcovr
@@ -19,7 +19,7 @@ RUN /bin/bash <<"EOF"
       use_params=''
       case ${compiler_version%%.*} in
         17)
-          emerge =dev-lang/python-3.12.11
+          emerge =dev-lang/python-3.12.11_p1
           use_params=python_single_target_python3_12 ;;
       esac
       echo ">llvm-runtimes/openmp-${compiler_version%%-r*}-r9999" >> /etc/portage/package.mask/llvm


### PR DESCRIPTION
Update GCC 15.1.0 -> 15.2.0
Update GCC 13.4.0 -> 13.4.1
Update GCC 12.4.1 -> 12.5.0
Update Clang trunk major version 21 -> 22
Add Clang 21.1.1
Update Clang 20.1.7 -> 20.1.8