### PR TITLE
Bump compiler versions; add jq; remove clang-p2996

### DIFF
--- a/.github/workflows/fromsource_ci.yml
+++ b/.github/workflows/fromsource_ci.yml
@@ -32,15 +32,12 @@ jobs:
       fail-fast: false
       matrix:
         compilers:
-          - kind: clang-p2996
-            compiler-version: 21.0.0.9999
-            tags: [latest, trunk]
           - kind: clang
-            compiler-version: 22.0.0_pre20250910
+            compiler-version: 22.0.0_pre20251223
             tags: [trunk]
           - kind: clang
-            compiler-version: 21.1.1
-            tags: [21.1.1, 21, latest]
+            compiler-version: 21.1.8
+            tags: [21.1.8, 21, latest]
           - kind: gcc
             compiler-version: 16.0.9999
             tags: [trunk]

--- a/.github/workflows/testing_ci.yml
+++ b/.github/workflows/testing_ci.yml
@@ -31,10 +31,10 @@ jobs:
       matrix:
         compilers:
           - kind: gcc
-            compiler-version: 15.2.0
+            compiler-version: 15.2.1_p20251122
             tags: [15.2.0, 15, latest]
           - kind: gcc
-            compiler-version: 14.3.0
+            compiler-version: 14.3.1_p20250801
             tags: [14.3.0, 14]
           - kind: gcc
             compiler-version: 13.4.1_p20250807
@@ -49,13 +49,13 @@ jobs:
             compiler-version: 20.1.8
             tags: [20.1.8, 20]
           - kind: clang
-            compiler-version: 19.1.7
+            compiler-version: 19.1.7-r1
             tags: [19.1.7, 19]
           - kind: clang
-            compiler-version: 18.1.8-r6
+            compiler-version: 18.1.8-r7
             tags: [18.1.8, 18]
           - kind: clang
-            compiler-version: 17.0.6
+            compiler-version: 17.0.6-r1
             tags: [17.0.6, 17]
     name: "${{ matrix.compilers.kind }}-${{ matrix.compilers.compiler-version }}"
     steps:

--- a/Dockerfile.fromsource
+++ b/Dockerfile.fromsource
@@ -25,24 +25,23 @@ EOF2
       emerge --sync
     fi
     echo 'ACCEPT_KEYWORDS="~amd64"' >> /etc/portage/make.conf
-    if [[ ${compiler_kind} == clang-p2996 ]] ; then
-      echo "=dev-build/cmake-4.0.3" >> /etc/portage/package.unmask
-      emerge =dev-build/cmake-4.0.3
-    else
-      echo "=dev-build/cmake-4.1.1" >> /etc/portage/package.unmask
-      emerge =dev-build/cmake-4.1.1
-    fi
+    echo "=dev-build/cmake-4.2.1" >> /etc/portage/package.unmask
+    emerge =dev-build/cmake-4.2.1
     emerge dev-build/ninja
     emerge dev-util/gcovr
+    emerge app-misc/jq
     if [[ ${compiler_kind} == clang* ]] ; then
-      USE="libcxx" emerge =llvm-core/clang-${compiler_version} --autounmask --autounmask-write || true
-      etc-update --automode -5
-      USE="libcxx" emerge =llvm-core/clang-${compiler_version}
+      export USE="libcxx"
+      if ! emerge =llvm-core/clang-${compiler_version} --autounmask --autounmask-write ; then
+        etc-update --automode -5
+        emerge =llvm-core/clang-${compiler_version}
+      fi
       ln -sv /usr/lib/llvm/${compiler_version%%.*}/bin/* /usr/local/bin/
     elif [[ ${compiler_kind} == gcc ]] ; then
-      emerge =sys-devel/gcc-${compiler_version} --autounmask --autounmask-write || true
-      etc-update --automode -5
-      emerge =sys-devel/gcc-${compiler_version}
+      if ! emerge =sys-devel/gcc-${compiler_version} --autounmask --autounmask-write ; then
+        etc-update --automode -5
+        emerge =sys-devel/gcc-${compiler_version}
+      fi
       eselect gcc set x86_64-pc-linux-gnu-${compiler_version%%\.*}
     else
       exit 1

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -10,11 +10,12 @@ RUN /bin/bash <<"EOF"
     emerge-webrsync
     getuto
     echo 'ACCEPT_KEYWORDS="~amd64"' >> /etc/portage/make.conf
-    echo "=dev-build/cmake-4.1.1" >> /etc/portage/package.unmask
-    emerge =dev-build/cmake-4.1.1
+    echo "=dev-build/cmake-4.2.1" >> /etc/portage/package.unmask
+    emerge =dev-build/cmake-4.2.1
     emerge dev-build/ninja
     emerge dev-vcs/git
     emerge dev-util/gcovr
+    emerge app-misc/jq
     if [[ ${compiler_kind} == clang ]] ; then
       use_params=''
       case ${compiler_version%%.*} in

--- a/README.md
+++ b/README.md
@@ -21,13 +21,11 @@ This project builds the following images intended for use by CI for Beman librar
   - `11`/`11.5.0`
 - `ghcr.io/bemanproject/infra-containers-clang`
   - `trunk` (rebuilt weekly)
-  - `latest`/`21`/`21.1.1`
+  - `latest`/`21`/`21.1.8`
   - `20`/`20.1.8`
   - `19`/`19.1.7`
   - `18`/`18.1.8`
   - `17`/`17.0.6`
-- `ghcr.io/bemanproject/infra-containers-clang-p2996`
-  - `latest`/`trunk` (rebuilt weekly)
 
 It also builds the following images intended for use by Docker codespaces:
 
@@ -36,9 +34,8 @@ It also builds the following images intended for use by Docker codespaces:
 - `ghcr.io/bemanproject/infra-containers-devcontainer-clang`
   - `latest`/`20`
 
-Along with the compiler version specified in the tag, these images contain CMake 4.1.1
-(except for the clang-p2996 image, which contains CMake 4.0.3) and recent versions of
-ninja and git.
+Along with the compiler version specified in the tag, these images contain CMake 4.2.1 and
+recent versions of ninja, git, and jq.
 
 ## Implementation Details
 


### PR DESCRIPTION
Unfortunately, fixing the clang-p2996 build is a work in progress. This should restorethe other containers. jq is needed for a new CI step that uses the cmake-file-api(7).