### PR TITLE
Version bumps

### DIFF
--- a/.github/workflows/fromsource_ci.yml
+++ b/.github/workflows/fromsource_ci.yml
@@ -35,11 +35,11 @@ jobs:
       matrix:
         compilers:
           - kind: clang
-            compiler-version: 23.0.0_pre20260314
+            compiler-version: 23.0.0_pre20260321
             tags: [trunk]
           - kind: clang
-            compiler-version: 22.1.1
-            tags: [22.1.1, 22, latest]
+            compiler-version: 22.1.2
+            tags: [22.1.2, 22, latest]
           - kind: gcc
             compiler-version: 16.0.9999
             tags: [trunk]
@@ -106,13 +106,13 @@ jobs:
       matrix:
         compilers:
           - kind: clang
-            compiler-version: 22.1.1
-            tags: [22.1.1, 22, latest]
+            compiler-version: 22.1.2
+            tags: [22.1.2, 22, latest]
           - kind: gcc
             compiler-version: 16.0.9999
             tags: [trunk]
           - kind: gcc
-            compiler-version: 13.4.1_p20250807
+            compiler-version: 13.4.1_p20260212
             tags: [13.4.1, 13]
           - kind: gcc
             compiler-version: 12.5.0
@@ -183,16 +183,16 @@ jobs:
       matrix:
         compilers:
           - kind: clang
-            compiler-version: 23.0.0_pre20260314
+            compiler-version: 23.0.0_pre20260321
             tags: [trunk]
           - kind: clang
-            compiler-version: 22.1.1
-            tags: [22.1.1, 22, latest]
+            compiler-version: 22.1.2
+            tags: [22.1.2, 22, latest]
           - kind: gcc
             compiler-version: 16.0.9999
             tags: [trunk]
           - kind: gcc
-            compiler-version: 13.4.1_p20250807
+            compiler-version: 13.4.1_p20260212
             tags: [13.4.1, 13]
           - kind: gcc
             compiler-version: 12.5.0

--- a/.github/workflows/testing_ci.yml
+++ b/.github/workflows/testing_ci.yml
@@ -33,13 +33,13 @@ jobs:
       matrix:
         compilers:
           - kind: gcc
-            compiler-version: 15.2.1_p20251122
-            tags: [15.2.0, 15, latest]
+            compiler-version: 15.2.1_p20260214
+            tags: [15.2.1, 15, latest]
           - kind: gcc
             compiler-version: 14.3.1_p20250801
-            tags: [14.3.0, 14]
+            tags: [14.3.1, 14]
           - kind: gcc
-            compiler-version: 13.4.1_p20250807
+            compiler-version: 13.4.1_p20260212
             tags: [13.4.1, 13]
           - kind: gcc
             compiler-version: 12.5.0
@@ -124,11 +124,11 @@ jobs:
       matrix:
         compilers:
           - kind: gcc
-            compiler-version: 15.2.1_p20251122
-            tags: [15.2.0, 15, latest]
+            compiler-version: 15.2.1_p20260214
+            tags: [15.2.1, 15, latest]
           - kind: gcc
             compiler-version: 14.3.1_p20250801
-            tags: [14.3.0, 14]
+            tags: [14.3.1, 14]
           - kind: clang
             compiler-version: 21.1.8
             tags: [21.1.8, 21]
@@ -195,13 +195,13 @@ jobs:
       matrix:
         compilers:
           - kind: gcc
-            compiler-version: 15.2.1_p20251122
-            tags: [15.2.0, 15, latest]
+            compiler-version: 15.2.1_p20260214
+            tags: [15.2.1, 15, latest]
           - kind: gcc
             compiler-version: 14.3.1_p20250801
-            tags: [14.3.0, 14]
+            tags: [14.3.1, 14]
           - kind: gcc
-            compiler-version: 13.4.1_p20250807
+            compiler-version: 13.4.1_p20260212
             tags: [13.4.1, 13]
           - kind: gcc
             compiler-version: 12.5.0

--- a/Dockerfile.fromsource
+++ b/Dockerfile.fromsource
@@ -32,10 +32,10 @@ EOF2
       emerge --sync
     fi
     echo "ACCEPT_KEYWORDS=\"~${GENTOO_ARCH}\"" >> /etc/portage/make.conf
-    echo "=dev-build/cmake-4.2.3" >> /etc/portage/package.unmask
+    echo "=dev-build/cmake-4.3.1" >> /etc/portage/package.unmask
     mkdir -p /etc/portage/package.accept_keywords
     echo "dev-util/gcovr **" >> /etc/portage/package.accept_keywords/gcovr
-    emerge =dev-build/cmake-4.2.3
+    emerge =dev-build/cmake-4.3.1
     emerge dev-build/ninja
     emerge dev-util/gcovr
     emerge app-misc/jq

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -17,10 +17,10 @@ RUN /bin/bash <<"EOF"
         *)        echo "Unsupported arch: $(uname -m)"; exit 1 ;;
     esac
     echo "ACCEPT_KEYWORDS=\"~${GENTOO_ARCH}\"" >> /etc/portage/make.conf
-    echo "=dev-build/cmake-4.2.3" >> /etc/portage/package.unmask
+    echo "=dev-build/cmake-4.3.1" >> /etc/portage/package.unmask
     mkdir -p /etc/portage/package.accept_keywords
     echo "dev-util/gcovr **" >> /etc/portage/package.accept_keywords/gcovr
-    emerge =dev-build/cmake-4.2.3
+    emerge =dev-build/cmake-4.3.1
     emerge dev-build/ninja
     emerge dev-vcs/git
     emerge dev-util/gcovr


### PR DESCRIPTION
- CMake to 4.3.1
- clang trunk to 23.0.0_pre20260321
- clang 22 to 22.1.2
- gcc 13 to 13.4.1_p20260212
- gcc 14 to 14.3.1_p20260213
- gcc 15 to 15.2.1_p20260214
